### PR TITLE
Loosen dependency on sourceLookup

### DIFF
--- a/com.ifedorenko.m2e.mavendev.feature/feature.xml
+++ b/com.ifedorenko.m2e.mavendev.feature/feature.xml
@@ -21,16 +21,13 @@ Maven repository.
    </license>
 
    <includes
-         id="com.ifedorenko.m2e.sourcelookup.feature"
-         version="0.0.0"/>
-
-   <includes
          id="io.takari.stats.m2e.feature"
          version="0.0.0"/>
 
    <requires>
       <import feature="org.eclipse.jdt" version="3.8.0" match="compatible"/>
       <import feature="org.sonatype.m2e.mavenarchiver.feature" version="0.15.0" match="compatible"/>
+      <import feature="com.ifedorenko.m2e.sourcelookup.feature" version="1.1.0"/>
    </requires>
 
    <plugin

--- a/com.ifedorenko.m2e.mavendev.repository/category.xml
+++ b/com.ifedorenko.m2e.mavendev.repository/category.xml
@@ -3,5 +3,8 @@
    <feature url="com.ifedorenko.m2e.mavendev.feature_0.0.0.qualifier.jar" id="com.ifedorenko.m2e.mavendev.feature" version="0.0.0">
       <category name="org.eclipse.m2e.extensions"/>
    </feature>
+   <feature url="features/com.ifedorenko.m2e.sourcelookup.feature_0.0.0.qualifier.jar" id="com.ifedorenko.m2e.sourcelookup.feature" version="0.0.0">
+      <category name="org.eclipse.m2e.extensions"/>
+   </feature>
    <category-def name="org.eclipse.m2e.extensions" label="m2e extensions"/>
 </site>


### PR DESCRIPTION
Right now it's impossible to install mavendev and a version of sourceLookup other than the one mavendev was build with.